### PR TITLE
Implement SymbolTable module

### DIFF
--- a/assembler.rb
+++ b/assembler.rb
@@ -48,9 +48,13 @@ class Assembler
       @parser.advance
       if @parser.command_type == :A_COMMAND
         a_symbol = @parser.symbol 
-        
-        if @symbol_table.contains?(a_symbol)
-          a_symbol = @symbol_table.get_address(a_symbol)
+
+        if a_symbol.to_i.to_s != a_symbol
+          if @symbol_table.contains?(a_symbol)
+            a_symbol = @symbol_table.get_address(a_symbol)
+          else
+            a_symbol = 16
+          end
         end
         
         binary_instructions << (sprintf("0%015b", a_symbol))

--- a/assembler.rb
+++ b/assembler.rb
@@ -10,8 +10,36 @@ class Assembler
     add_predefined_symbols
   end
 
+  PREDEFINED_SYMBOLS = {
+    "SP" => 0,
+    "LCL" => 1,
+    "ARG" => 2,
+    "THIS" => 3,
+    "THAT" => 4,
+    "R0" => 0,
+    "R1" => 1,
+    "R2" => 2,
+    "R3" => 3,
+    "R4" => 4,
+    "R5" => 5,
+    "R6" => 6,
+    "R7" => 7,
+    "R8" => 8,
+    "R9" => 9,
+    "R10" => 10,
+    "R11" => 11,
+    "R12" => 12,
+    "R13" => 13,
+    "R14" => 14,
+    "R15" => 15,
+    "SCREEN" => 16384,
+    "KBD" => 24576,
+  }
+
   def add_predefined_symbols
-    @symbol_table.add_entry("SCREEN", 16384)
+    PREDEFINED_SYMBOLS.each do |symbol, address|
+      @symbol_table.add_entry(symbol, address)
+    end
   end
 
   def assemble

--- a/assembler.rb
+++ b/assembler.rb
@@ -49,7 +49,8 @@ class Assembler
 
     while @parser.has_more_commands? 
       @parser.advance
-      if @parser.command_type == :L_COMMAND
+      case @parser.command_type
+      when :L_COMMAND
         @symbol_table.add_entry(@parser.symbol, @instruction_address)
       else 
         @instruction_address += 1
@@ -62,7 +63,8 @@ class Assembler
     binary_instructions = []
     while @parser.has_more_commands?
       @parser.advance
-      if @parser.command_type == :A_COMMAND
+      case @parser.command_type
+      when :A_COMMAND
         a_symbol = @parser.symbol 
 
         if a_symbol.to_i.to_s != a_symbol
@@ -74,7 +76,7 @@ class Assembler
         end
         
         binary_instructions << (sprintf("0%015b", a_symbol))
-      elsif @parser.command_type == :C_COMMAND
+      when :C_COMMAND
         comp, dest, jump = @parser.comp, @parser.dest, @parser.jump
         comp, dest, jump = @code.comp(comp), @code.dest(dest), @code.jump(jump)
         binary_instructions << "111#{comp}#{dest}#{jump}"

--- a/assembler.rb
+++ b/assembler.rb
@@ -1,10 +1,17 @@
 require_relative "parser"
 require_relative "code"
+require_relative "symbol_table"
 
 class Assembler
   def initialize(input_file)
     @parser = Parser.new(input_file)
     @code = Code.new
+    @symbol_table = SymbolTable.new
+    add_predefined_symbols
+  end
+
+  def add_predefined_symbols
+    @symbol_table.add_entry("SCREEN", 16384)
   end
 
   def assemble
@@ -13,6 +20,11 @@ class Assembler
       @parser.advance
       if @parser.command_type == :A_COMMAND
         a_symbol = @parser.symbol 
+        
+        if @symbol_table.contains?(a_symbol)
+          a_symbol = @symbol_table.get_address(a_symbol)
+        end
+        
         binary_instructions << (sprintf("0%015b", a_symbol))
       elsif @parser.command_type == :C_COMMAND
         comp, dest, jump = @parser.comp, @parser.dest, @parser.jump

--- a/assembler.rb
+++ b/assembler.rb
@@ -9,6 +9,7 @@ class Assembler
     @symbol_table = SymbolTable.new
     add_predefined_symbols
     @variable_address = 16
+    @instruction_address = 0
   end
 
   PREDEFINED_SYMBOLS = {
@@ -59,10 +60,14 @@ class Assembler
         end
         
         binary_instructions << (sprintf("0%015b", a_symbol))
+        @instruction_address += 1
       elsif @parser.command_type == :C_COMMAND
         comp, dest, jump = @parser.comp, @parser.dest, @parser.jump
         comp, dest, jump = @code.comp(comp), @code.dest(dest), @code.jump(jump)
         binary_instructions << "111#{comp}#{dest}#{jump}"
+        @instruction_address += 1
+      elsif @parser.command_type == :L_COMMAND
+        @symbol_table.add_entry(@parser.symbol, @instruction_address)
       end
     end
 

--- a/assembler.rb
+++ b/assembler.rb
@@ -51,12 +51,11 @@ class Assembler
         a_symbol = @parser.symbol 
 
         if a_symbol.to_i.to_s != a_symbol
-          if @symbol_table.contains?(a_symbol)
-            a_symbol = @symbol_table.get_address(a_symbol)
-          else
-            a_symbol = @variable_address
+          unless @symbol_table.contains?(a_symbol)
+            @symbol_table.add_entry(a_symbol, @variable_address)
             @variable_address += 1
           end
+          a_symbol = @symbol_table.get_address(a_symbol)
         end
         
         binary_instructions << (sprintf("0%015b", a_symbol))

--- a/assembler.rb
+++ b/assembler.rb
@@ -8,6 +8,7 @@ class Assembler
     @code = Code.new
     @symbol_table = SymbolTable.new
     add_predefined_symbols
+    @variable_address = 16
   end
 
   PREDEFINED_SYMBOLS = {
@@ -53,7 +54,8 @@ class Assembler
           if @symbol_table.contains?(a_symbol)
             a_symbol = @symbol_table.get_address(a_symbol)
           else
-            a_symbol = 16
+            a_symbol = @variable_address
+            @variable_address += 1
           end
         end
         

--- a/assembler.rb
+++ b/assembler.rb
@@ -5,7 +5,6 @@ require_relative "symbol_table"
 class Assembler
   def initialize(input_file)
     @input_file = input_file
-    @parser = Parser.new(@input_file)
     @code = Code.new
     @symbol_table = SymbolTable.new
     add_predefined_symbols
@@ -46,6 +45,8 @@ class Assembler
   end
 
   def assemble
+    @parser = Parser.new(@input_file)
+
     while @parser.has_more_commands? 
       @parser.advance
       if @parser.command_type == :L_COMMAND

--- a/assembler.rb
+++ b/assembler.rb
@@ -45,27 +45,27 @@ class Assembler
   end
 
   def assemble
-    @parser = Parser.new(@input_file)
+    parser = Parser.new(@input_file)
 
-    while @parser.has_more_commands? 
-      @parser.advance
-      case @parser.command_type
+    while parser.has_more_commands? 
+      parser.advance
+      case parser.command_type
       when :L_COMMAND
-        @symbol_table.add_entry(@parser.symbol, @instruction_address)
+        @symbol_table.add_entry(parser.symbol, @instruction_address)
       else 
         @instruction_address += 1
       end
     end
 
     @input_file.rewind
-    @parser = Parser.new(@input_file)
+    parser = Parser.new(@input_file)
 
     binary_instructions = []
-    while @parser.has_more_commands?
-      @parser.advance
-      case @parser.command_type
+    while parser.has_more_commands?
+      parser.advance
+      case parser.command_type
       when :A_COMMAND
-        a_symbol = @parser.symbol 
+        a_symbol = parser.symbol 
 
         if a_symbol.to_i.to_s != a_symbol
           unless @symbol_table.contains?(a_symbol)
@@ -77,7 +77,7 @@ class Assembler
         
         binary_instructions << (sprintf("0%015b", a_symbol))
       when :C_COMMAND
-        comp, dest, jump = @parser.comp, @parser.dest, @parser.jump
+        comp, dest, jump = parser.comp, parser.dest, parser.jump
         comp, dest, jump = @code.comp(comp), @code.dest(dest), @code.jump(jump)
         binary_instructions << "111#{comp}#{dest}#{jump}"
       end

--- a/assembler_test.rb
+++ b/assembler_test.rb
@@ -43,4 +43,10 @@ class AssemblerTest < Minitest::Test
     assembler = Assembler.new(input_file)
     assert_equal("0100000000000000", assembler.assemble)
   end
+
+  def test_assemble_predefined_symbols_with_numbers
+    input_file = StringIO.new("@R10")
+    assembler = Assembler.new(input_file)
+    assert_equal("0000000000001010", assembler.assemble)
+  end
 end

--- a/assembler_test.rb
+++ b/assembler_test.rb
@@ -86,4 +86,22 @@ class AssemblerTest < Minitest::Test
     assembler = Assembler.new(input_file)
     assert_equal("1111000010010000\n0000000000000001\n0000000000000010", assembler.assemble)
   end
+
+  def test_assemble_L_command_after_label
+    input_file = StringIO.new("@LOOP\n(LOOP)")
+    assembler = Assembler.new(input_file)
+    assert_equal("0000000000000001", assembler.assemble)
+  end
+
+  def test_assemble_L_command_in_a_different_position_after_label
+    input_file = StringIO.new("D=D+M\n@LOOP\n(LOOP)")
+    assembler = Assembler.new(input_file)
+    assert_equal("1111000010010000\n0000000000000010", assembler.assemble)
+  end
+
+  def test_assemble_multiple_L_commands_after_label
+    input_file = StringIO.new("D=D+M\n@LOOP\n(LOOP)\n@LOOP2\n(LOOP2)")
+    assembler = Assembler.new(input_file)
+    assert_equal("1111000010010000\n0000000000000010\n0000000000000011", assembler.assemble)
+  end
 end

--- a/assembler_test.rb
+++ b/assembler_test.rb
@@ -37,4 +37,10 @@ class AssemblerTest < Minitest::Test
     assembler = Assembler.new(input_file)
     assert_equal("1111000010010000", assembler.assemble)
   end
+
+  def test_assemble_predefined_symbols
+    input_file = StringIO.new("@SCREEN")
+    assembler = Assembler.new(input_file)
+    assert_equal("0100000000000000", assembler.assemble)
+  end
 end

--- a/assembler_test.rb
+++ b/assembler_test.rb
@@ -55,4 +55,10 @@ class AssemblerTest < Minitest::Test
     assembler = Assembler.new(input_file)
     assert_equal("0000000000010000", assembler.assemble)
   end
+
+  def test_assemble_two_variable_symbols
+    input_file = StringIO.new("@foo\n@bar")
+    assembler = Assembler.new(input_file)
+    assert_equal("0000000000010000\n0000000000010001", assembler.assemble)
+  end
 end

--- a/assembler_test.rb
+++ b/assembler_test.rb
@@ -68,4 +68,22 @@ class AssemblerTest < Minitest::Test
     assert_equal("0000000000010000\n0000000000010001\n"\
                  "0000000000010000\n0000000000010001", assembler.assemble)
   end
+
+  def test_assemble_L_command
+    input_file = StringIO.new("(LOOP)\n@LOOP")
+    assembler = Assembler.new(input_file)
+    assert_equal("0000000000000000", assembler.assemble)
+  end
+
+  def test_assemble_L_command_in_a_different_position
+    input_file = StringIO.new("D=D+M\n(LOOP)\n@LOOP")
+    assembler = Assembler.new(input_file)
+    assert_equal("1111000010010000\n0000000000000001", assembler.assemble)
+  end
+
+  def test_assemble_multiple_L_commands
+    input_file = StringIO.new("D=D+M\n(LOOP)\n@LOOP\n(LOOP2)\n@LOOP2")
+    assembler = Assembler.new(input_file)
+    assert_equal("1111000010010000\n0000000000000001\n0000000000000010", assembler.assemble)
+  end
 end

--- a/assembler_test.rb
+++ b/assembler_test.rb
@@ -49,4 +49,10 @@ class AssemblerTest < Minitest::Test
     assembler = Assembler.new(input_file)
     assert_equal("0000000000001010", assembler.assemble)
   end
+
+  def test_assemble_a_variable_symbol
+    input_file = StringIO.new("@foo")
+    assembler = Assembler.new(input_file)
+    assert_equal("0000000000010000", assembler.assemble)
+  end
 end

--- a/assembler_test.rb
+++ b/assembler_test.rb
@@ -61,4 +61,11 @@ class AssemblerTest < Minitest::Test
     assembler = Assembler.new(input_file)
     assert_equal("0000000000010000\n0000000000010001", assembler.assemble)
   end
+
+  def test_assemble_repeated_variable_symbols
+    input_file = StringIO.new("@foo\n@bar\n@foo\n@bar")
+    assembler = Assembler.new(input_file)
+    assert_equal("0000000000010000\n0000000000010001\n"\
+                 "0000000000010000\n0000000000010001", assembler.assemble)
+  end
 end

--- a/ruby_hack_assembler.rb
+++ b/ruby_hack_assembler.rb
@@ -2,4 +2,5 @@
 
 require_relative 'assembler'
 
-puts Assembler.new(ARGF).assemble
+input_file = File.open(ARGV[0].to_s)
+puts Assembler.new(input_file).assemble

--- a/ruby_hack_assembler_test.rb
+++ b/ruby_hack_assembler_test.rb
@@ -2,7 +2,6 @@ require "minitest/autorun"
 
 class RubyHackAssemblerTest < Minitest::Test
   def test_integration_test
-    skip("Assembly with symbols hasn't been implemented!")
     assembly_code = `ruby ruby_hack_assembler.rb examples/Rect.asm`
     expected = <<~EOF
       0000000000000000

--- a/symbol_table.rb
+++ b/symbol_table.rb
@@ -1,0 +1,17 @@
+class SymbolTable
+  def initialize
+    @symbol_table = {}
+  end
+
+  def contains?(symbol)
+    @symbol_table.key?(symbol)
+  end
+
+  def add_entry(symbol, address)
+    @symbol_table[symbol] = address
+  end
+
+  def get_address(symbol)
+    @symbol_table.fetch(symbol)
+  end
+end

--- a/symbol_table_test.rb
+++ b/symbol_table_test.rb
@@ -1,0 +1,24 @@
+require "minitest/autorun"
+require_relative "symbol_table"
+
+class SymbolTableTest < Minitest::Test
+  def test_add_entry_adds_symbol_and_address
+    symbol_table = SymbolTable.new
+    refute(symbol_table.contains?("LOOP"))
+    symbol_table.add_entry("LOOP", 5)
+    assert(symbol_table.contains?("LOOP"))
+  end
+
+  def test_get_address_returns_the_address
+    symbol_table = SymbolTable.new
+    symbol_table.add_entry("LOOP", 5)
+    assert_equal(5, symbol_table.get_address("LOOP"))
+  end
+
+  def test_multiple_entries_with_same_key
+    symbol_table = SymbolTable.new
+    symbol_table.add_entry("LOOP", 5)
+    symbol_table.add_entry("LOOP", 6)
+    assert_equal(6, symbol_table.get_address("LOOP"))
+  end
+end


### PR DESCRIPTION
The SymbolTable stores symbols that resolve to addresses. 

For example,

```
(LOOP) # Pseudo-command/Label for LOOP 
A
D
LOOP # Symbol for the label above
```

The symbol `LOOP` is then evaluated to the address of `(LOOP)`, which is 0 in this case. 

This change:
* Implements the SymbolTable module
* Hooks up the SymbolTable to the Assembler 
* Unskip integration tests! 